### PR TITLE
[ajaust] Add building and container recipes 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION "3.12")
+
+FIND_PACKAGE(deal.II 9.1.0 REQUIRED
+  HINTS ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}
+  )
+DEAL_II_INITIALIZE_CACHED_VARIABLES()
+
+project("cmake-exercise-ajaust")
+
+find_package(Boost
+  1.71.0
+  REQUIRED
+  filesystem
+  )
+
+find_package(yaml-cpp
+  0.7.0
+  REQUIRED
+  )
+
+message(STATUS "${YAML_CPP_INCLUDE_DIR}")
+message(STATUS "${YAML_CPP_LIBRARIES}")
+
+add_executable("${PROJECT_NAME}" main.cpp fem/fem.cpp flatset/flatset.cpp filesystem/filesystem.cpp yamlParser/yamlParser.cpp)
+target_link_libraries("${PROJECT_NAME}" Boost::filesystem)
+
+include_directories(${YAML_CPP_INCLUDE_DIR})
+target_link_libraries("${PROJECT_NAME}" ${YAML_CPP_LIBRARIES})
+
+DEAL_II_SETUP_TARGET("${PROJECT_NAME}")
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:20.04
+
+COPY inittimezone /usr/local/bin/inittimezone
+
+RUN inittimezone && apt update -y && apt install -y build-essential cmake libboost-all-dev libdeal.ii-dev git wget vim htop sudo
+RUN apt install -y curl
+
+# Cleanup
+RUN apt-get clean
+#RUN rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*
+RUN rm -rf /tmp/*
+
+# Create user
+ARG USER_NAME=alex
+ARG USER_HOME=/home/${USER_NAME}
+#ARG USER_ID=1000
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+RUN groupadd -g $GROUP_ID "$USER_NAME"
+RUN adduser \
+    --home "$USER_HOME" \
+    --uid $USER_ID \
+    --gid $GROUP_ID \
+    --disabled-password \
+    "$USER_NAME"
+
+RUN echo "$USER_NAME" ALL=\(root\) NOPASSWD:ALL > "/etc/sudoers.d/$USER_NAME" && \
+    chmod 0440 "/etc/sudoers.d/$USER_NAME"
+
+USER "$USER_NAME"
+WORKDIR "$USER_HOME"
+
+RUN git clone https://github.com/ajaust/dotfiles.git && cd dotfiles && ./setup_dotfiles.sh && curl -L https://raw.github.com/git/git/v$(git --version | cut -d' ' -f3)/contrib/completion/git-prompt.sh > ~/.git-prompt.sh
+
+# Install yaml-cpp version 0.7.0
+RUN git clone -b yaml-cpp-0.7.0 https://github.com/jbeder/yaml-cpp.git yaml-cpp && cd yaml-cpp/ &&mkdir -p build && cd build && cmake -DCMAKE_INSTALL_PREFIX=${HOME}/software/yaml-cpp/0.7.0 -DYAML_BUILD_SHARED_LIBS=ON .. && make -j && make test && make install
+
+# Overwrite generated cmake file from yaml-cpp
+COPY yaml-cpp-config.cmake_fixed ${USER_HOME}/software/yaml-cpp/0.7.0/share/cmake/yaml-cpp/yaml-cpp-config.cmake
+COPY build-project.sh ${USER_HOME}/bin/build-project.sh
+ENV PATH ${USER_HOME}/bin:${PATH}
+
+CMD ["bash"]

--- a/build-project.sh
+++ b/build-project.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ $# = 0 ]]; then
+    echo $1
+    mkdir -p build && cd build
+    cmake -Dyaml-cpp_DIR="${HOME}/software/yaml-cpp/0.7.0/share/cmake/yaml-cpp" /mnt/cmake-exercise
+else
+    echo $1
+    cmake -Dyaml-cpp_DIR="${HOME}/software/yaml-cpp/0.7.0/share/cmake/yaml-cpp" $1
+fi
+make -j

--- a/main.cpp
+++ b/main.cpp
@@ -1,28 +1,28 @@
-//#include "fem/fem.hpp"
-//#include "flatset/flatset.hpp"
-//#include "filesystem/filesystem.hpp"
-//#include "yamlParser/yamlParser.hpp"
+#include "fem/fem.hpp"
+#include "flatset/flatset.hpp"
+#include "filesystem/filesystem.hpp"
+#include "yamlParser/yamlParser.hpp"
 #include <iostream>
 
 int main()
 {
   std::cout << "Let's fight with CMake, Docker, and some dependencies!" << std::endl << std::endl;
 
-  //std::cout << "Solve Poisson problem with FEM using deal.II" << std::endl;
-  //Fem fem;
-  //fem.run();
-  //std::cout << std::endl;
+  std::cout << "Solve Poisson problem with FEM using deal.II" << std::endl;
+  Fem fem;
+  fem.run();
+  std::cout << std::endl;
 
-  //std::cout << "Modify a flat set using boost container" << std::endl;
-  //modifyAndPrintSets();
-  //std::cout << std::endl;
+  std::cout << "Modify a flat flatset using boost container" << std::endl;
+  modifyAndPrintSets();
+  std::cout << std::endl;
 
-  //std::cout << "Inspect the current directory using boost filesystem" << std::endl;
-  //inspectDirectory();
-  //std::cout << std::endl;
+  std::cout << "Inspect the current directory using boost filesystem" << std::endl;
+  inspectDirectory();
+  std::cout << std::endl;
 
-  //std::cout << "Parse some yaml file with yaml-cpp" << std::endl;
-  //parseConfig();
+  std::cout << "Parse some yaml file with yaml-cpp" << std::endl;
+  parseConfig();
 
   return 0;
 }

--- a/yaml-cpp-config.cmake_fixed
+++ b/yaml-cpp-config.cmake_fixed
@@ -1,0 +1,9 @@
+# Compute paths
+get_filename_component(YAML_CPP_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+# Our library dependencies (contains definitions for IMPORTED targets)
+include("${YAML_CPP_CMAKE_DIR}/yaml-cpp-targets.cmake")
+
+# These are IMPORTED targets created by yaml-cpp-targets.cmake
+get_target_property(YAML_CPP_INCLUDE_DIR yaml-cpp INTERFACE_INCLUDE_DIRECTORIES)
+set(YAML_CPP_LIBRARIES "yaml-cpp")

--- a/yamlParser/yamlParser.cpp
+++ b/yamlParser/yamlParser.cpp
@@ -3,6 +3,6 @@
 #include <iostream>
 
 void parseConfig(){
-  YAML::Node config = YAML::LoadFile("../yaml/config.yml");
+  YAML::Node config = YAML::LoadFile("../yamlParser/config.yml");
   std::cout << "Version: " << config["version"].as<std::string>() << std::endl;
 }


### PR DESCRIPTION
Compiling `yaml-cpp` and getting it linked to my project was a bit trick. I tried to use `yaml-cpp` by finding it via CMake. However, it is a bit hard to properly define the needed environment variable as it would need to include a hyphen `-` which is illegal. Therefore, I have to pass the variable to `cmake` directly. Thus I abstracted parts of the build process in a file called `build-project.sh` that can be used to build this repository.

There is a patch included due to problems with the exported symbols by `yaml-cpp` as mentioned in https://github.com/jbeder/yaml-cpp/issues/774. Therefore, I copy `yaml-cpp-config.cmake_fixed` into the container which fixes the issue for me.

