### PR TITLE
Add building and container recipes [uekerman solution]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION "3.12")
+
+project("CMakeExercise")
+
+file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS main.cpp fem/fem.cpp filesystem/filesystem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+add_executable(main "${SRC_FILES}")
+
+# We rely that the system installation of deal.II is found
+find_package(deal.II 9.1 REQUIRED)
+
+# deal.II magic macros for linking
+DEAL_II_INITIALIZE_CACHED_VARIABLES()
+DEAL_II_SETUP_TARGET(main)
+
+# Uses the FindBoost module of CMake
+find_package(Boost 1.65.1 COMPONENTS filesystem REQUIRED)
+
+target_link_libraries(main Boost::filesystem yaml-cpp)
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+From ubuntu:20.04
+
+COPY inittimezone /usr/local/bin/inittimezone
+
+# Run inittimezone and install a few dependencies
+RUN apt-get -qq update && \
+    inittimezone && \
+    apt-get -qq -y install \
+        build-essential \
+        cmake \
+        g++ \
+        git \
+        libboost-all-dev \
+        wget \
+        libdeal.ii-dev \
+        vim
+    
+# This is some strang Docker problem. Normally, you don't need to add /usr/local/lib to LIBRARY_PATH
+ENV LIBRARY_PATH $LIBRARY_PATH:/usr/local/lib/
+
+# Get, unpack, build, and install yaml-cpp        
+RUN mkdir Software && cd Software && \
+    wget https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.tar.gz && \
+    tar -xvzf yaml-cpp-0.7.0.tar.gz && \
+    cd yaml-cpp-yaml-cpp-0.7.0 && mkdir build && cd build && \
+    cmake -DYAML_BUILD_SHARED_LIBS=OFF .. && make -j4 && make install
+
+# I just copy the complete folder to the container
+ADD . /cmake-exercise
+CMD ["/bin/bash"]


### PR DESCRIPTION
I tried to do a minimal solution. I use the deal.II magic as explained in the [deal.II docs](https://www.dealii.org/current/users/cmake_user.html) and install `yaml-cpp` to the system path.

Within the container, you can do:

```bash
cd cmake-exercise
mkdir build
cd build
cmake DCMAKE_BUILD_TYPE=Release ..
make -j
./main
```

See also comments in `Dockerfile` and `CMakeLists.txt`.