### PR TITLE
Add building and container recipes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.24)
+
+project("CMakeExercise")
+
+find_package(Boost REQUIRED COMPONENTS container filesystem)
+
+find_package(deal.II REQUIRED CONFIG)
+deal_ii_initialize_cached_variables()
+
+find_package(yaml-cpp REQUIRED)
+
+add_library(fem fem/fem.cpp)
+deal_ii_setup_target(fem)
+
+add_library(filesystem filesystem/filesystem.cpp)
+add_library(flatset flatset/flatset.cpp)
+
+add_library(yamlParser yamlParser/yamlParser.cpp)
+target_link_libraries(yamlParser PRIVATE yaml-cpp)
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE fem filesystem flatset yamlParser  ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04
+
+WORKDIR /cmake-exercise
+
+ADD . /cmake-exercise
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y build-essential cmake nano wget unzip libboost-all-dev libdeal.ii-dev
+RUN wget -O /tmp/yaml-cpp.zip https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.6.3.zip \
+    && unzip /tmp/yaml-cpp.zip -d /tmp/yaml-cpp \
+    && mkdir  /tmp/yaml-cpp/build \
+    && cd /tmp/yaml-cpp/build \
+    && cmake /tmp/yaml-cpp/yaml-cpp-yaml-cpp-0.6.3 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && make install
+
+CMD ["/bin/bash"]

--- a/main.cpp
+++ b/main.cpp
@@ -1,39 +1,39 @@
-//#include "fem/fem.hpp"
-//#include "flatset/flatset.hpp"
-//#include "filesystem/filesystem.hpp"
-//#include "yamlParser/yamlParser.hpp"
+#include "fem/fem.hpp"
+#include "flatset/flatset.hpp"
+#include "filesystem/filesystem.hpp"
+#include "yamlParser/yamlParser.hpp"
 #include <iostream>
 
 int main(int argc, char *argv[])
 {
   std::cout << "Let's fight with CMake, Docker, and some dependencies!" << std::endl << std::endl;
 
-  //std::cout << "Solve Poisson problem with FEM using deal.II" << std::endl;
-  //Fem fem;
-  //fem.run();
-  //std::cout << std::endl;
+  std::cout << "Solve Poisson problem with FEM using deal.II" << std::endl;
+  Fem fem;
+  fem.run();
+  std::cout << std::endl;
 
-  //std::cout << "Modify a flat set using boost container" << std::endl;
-  //modifyAndPrintSets();
-  //std::cout << std::endl;
+  std::cout << "Modify a flat set using boost container" << std::endl;
+  modifyAndPrintSets();
+  std::cout << std::endl;
 
-  //std::cout << "Inspect the current directory using boost filesystem" << std::endl;
-  //inspectDirectory();
-  //std::cout << std::endl;
+  std::cout << "Inspect the current directory using boost filesystem" << std::endl;
+  inspectDirectory();
+  std::cout << std::endl;
 
-  
-  //if ( argc == 2 )
-  //{
-  //  const std::string yamlFile( argv[1] );
-  //  std::cout << "Parse some yaml file with yaml-cpp" << std::endl;
-  //  std::cout << "  " << yamlFile << std::endl;
-  //  parseConfig( yamlFile );
-  //}
-  //else
-  //{
-  //  std::cout << "To parse a yaml file please specify file on command line" << std::endl;
-  //  std::cout << "  ./main YAMLFILE" << std::endl;
-  //}
+
+  if ( argc == 2 )
+  {
+   const std::string yamlFile( argv[1] );
+   std::cout << "Parse some yaml file with yaml-cpp" << std::endl;
+   std::cout << "  " << yamlFile << std::endl;
+   parseConfig( yamlFile );
+  }
+  else
+  {
+   std::cout << "To parse a yaml file please specify file on command line" << std::endl;
+   std::cout << "  ./main YAMLFILE" << std::endl;
+  }
 
   return 0;
 }


### PR DESCRIPTION
I was not sure how 

> From your pull request, it should be possible to create an executable container. After running the container, it should be possible to cd into cmake-exercise and then run the build_and_run.sh script.

was meant. I assumed it means that
- there should be a Dockerfile that can be built
- when running and interactively entering the container, there is a directory cmake-exercise, where `build_and_run.sh` can be run